### PR TITLE
feat: aggiungi operazione inversione cifre flip (#12)

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -12,11 +12,12 @@ const OperationType = {
     NEGATE: '+-',
     // Operazioni speciali (non componibili)
     ABS: '|x|',
-    SQUARE: 'x²'
+    SQUARE: 'x²',
+    FLIP: 'flip'
 };
 
 // Operazioni speciali: non si compongono con altre operazioni
-const SpecialOperations = [OperationType.ABS, OperationType.SQUARE];
+const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP];
 
 // Categorie di difficoltà
 const DifficultyCategory = {
@@ -28,7 +29,8 @@ const DifficultyCategory = {
     FINAL: { name: 'Sfida Finale', range: [20, 24] },
     TRASH: { name: 'Cestino', range: [25, 28] },
     ABS: { name: 'Valore Assoluto', range: [29, 30] },
-    SQUARE: { name: 'Quadrato', range: [31, 32] }
+    SQUARE: { name: 'Quadrato', range: [31, 32] },
+    FLIP: { name: 'Inversione Cifre', range: [33, 34] }
 };
 
 // Funzione helper per ottenere la categoria di difficoltà di un livello
@@ -474,6 +476,28 @@ const levels = [
             { type: SquareType.NUMBER, value: -3 },
             { type: SquareType.NUMBER, value: 9 },
             { type: SquareType.OPERATION, value: OperationType.SQUARE }
+        ]
+    },
+    // === FLIP (34-35) ===
+    {
+        name: "Specchio",
+        // Soluzione: 12×flip=21, 21+21 spariscono
+        solution: "12×flip=21, 21+21 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 12 },
+            { type: SquareType.NUMBER, value: 21 },
+            { type: SquareType.OPERATION, value: OperationType.FLIP }
+        ]
+    },
+    {
+        name: "Palindromo",
+        // Soluzione: flip+flip spariscono, 11+11 spariscono (palindromo non cambia)
+        solution: "flip+flip spariscono, 11+11 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 11 },
+            { type: SquareType.NUMBER, value: 11 },
+            { type: SquareType.OPERATION, value: OperationType.FLIP },
+            { type: SquareType.OPERATION, value: OperationType.FLIP }
         ]
     }
 ];

--- a/script.js
+++ b/script.js
@@ -31,6 +31,8 @@ class SquareContent {
                 return 'Valore assoluto';
             case OperationType.SQUARE:
                 return 'Eleva al quadrato';
+            case OperationType.FLIP:
+                return 'Inverti cifre';
         }
     }
 
@@ -51,6 +53,11 @@ function applyOperation(num, operationContent) {
             return Math.abs(num);
         case OperationType.SQUARE:
             return num * num;
+        case OperationType.FLIP:
+            // Inverti le cifre del numero, mantieni il segno
+            const sign = num < 0 ? -1 : 1;
+            const flipped = parseInt(Math.abs(num).toString().split('').reverse().join(''), 10);
+            return sign * flipped;
     }
 
     // Se è un contenuto con composedMultiplier o getMultiplier può gestirlo


### PR DESCRIPTION
## Summary
- Aggiunta nuova operazione `flip` che inverte l'ordine delle cifre
- Esempi: `12` → `21`, `100` → `1`, `-12` → `-21`
- I numeri palindromi (11, 22, 121) non cambiano
- Due flip si annullano (spariscono)

## Test plan
- [ ] Verificare che `flip` applicato a 12 produca 21
- [ ] Verificare che `flip` applicato a 100 produca 1 (zeri rimossi)
- [ ] Verificare che `flip` applicato a -12 produca -21
- [ ] Verificare che `flip + flip` spariscano
- [ ] Completare i livelli 34 e 35 ("Specchio" e "Palindromo")

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)