### PR TITLE
feat: aggiungi operazione somma cifre Σ (#16)

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -13,11 +13,12 @@ const OperationType = {
     // Operazioni speciali (non componibili)
     ABS: '|x|',
     SQUARE: 'x²',
-    FLIP: 'flip'
+    FLIP: 'flip',
+    SUM_DIGITS: 'Σ'
 };
 
 // Operazioni speciali: non si compongono con altre operazioni
-const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP];
+const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP, OperationType.SUM_DIGITS];
 
 // Categorie di difficoltà
 const DifficultyCategory = {
@@ -30,7 +31,8 @@ const DifficultyCategory = {
     TRASH: { name: 'Cestino', range: [25, 28] },
     ABS: { name: 'Valore Assoluto', range: [29, 30] },
     SQUARE: { name: 'Quadrato', range: [31, 32] },
-    FLIP: { name: 'Inversione Cifre', range: [33, 34] }
+    FLIP: { name: 'Inversione Cifre', range: [33, 34] },
+    SUM_DIGITS: { name: 'Somma Cifre', range: [35, 36] }
 };
 
 // Funzione helper per ottenere la categoria di difficoltà di un livello
@@ -498,6 +500,28 @@ const levels = [
             { type: SquareType.NUMBER, value: 11 },
             { type: SquareType.OPERATION, value: OperationType.FLIP },
             { type: SquareType.OPERATION, value: OperationType.FLIP }
+        ]
+    },
+    // === SOMMA CIFRE (36-37) ===
+    {
+        name: "Riduzione",
+        // Soluzione: 234×Σ=9, 9+9 spariscono
+        solution: "234×Σ=9, 9+9 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 234 },
+            { type: SquareType.NUMBER, value: 9 },
+            { type: SquareType.OPERATION, value: OperationType.SUM_DIGITS }
+        ]
+    },
+    {
+        name: "Doppia Somma",
+        // Soluzione: 99×Σ=18, 18×Σ=9, 9+9 spariscono
+        solution: "99×Σ=18, 18×Σ=9, 9+9 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 99 },
+            { type: SquareType.NUMBER, value: 9 },
+            { type: SquareType.OPERATION, value: OperationType.SUM_DIGITS },
+            { type: SquareType.OPERATION, value: OperationType.SUM_DIGITS }
         ]
     }
 ];

--- a/script.js
+++ b/script.js
@@ -33,6 +33,8 @@ class SquareContent {
                 return 'Eleva al quadrato';
             case OperationType.FLIP:
                 return 'Inverti cifre';
+            case OperationType.SUM_DIGITS:
+                return 'Somma cifre';
         }
     }
 
@@ -53,11 +55,18 @@ function applyOperation(num, operationContent) {
             return Math.abs(num);
         case OperationType.SQUARE:
             return num * num;
-        case OperationType.FLIP:
+        case OperationType.FLIP: {
             // Inverti le cifre del numero, mantieni il segno
             const sign = num < 0 ? -1 : 1;
             const flipped = parseInt(Math.abs(num).toString().split('').reverse().join(''), 10);
             return sign * flipped;
+        }
+        case OperationType.SUM_DIGITS: {
+            // Somma le cifre del numero, mantieni il segno
+            const sign = num < 0 ? -1 : 1;
+            const sum = Math.abs(num).toString().split('').reduce((acc, d) => acc + parseInt(d, 10), 0);
+            return sign * sum;
+        }
     }
 
     // Se è un contenuto con composedMultiplier o getMultiplier può gestirlo


### PR DESCRIPTION
## Summary
- Aggiunta nuova operazione `Σ` che somma le cifre del numero
- Esempi: `234` → `9`, `99` → `18`, `-234` → `-9`
- Operazione che riduce i numeri grandi

## Test plan
- [ ] Verificare che `Σ` applicato a 234 produca 9
- [ ] Verificare che `Σ` applicato a 99 produca 18
- [ ] Verificare che `Σ` applicato a -234 produca -9
- [ ] Completare i livelli 36 e 37 ("Riduzione" e "Doppia Somma")

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)