### PR TITLE
feat: aggiungi operazione potenza di 2 2^n (#14)

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -18,11 +18,12 @@ const OperationType = {
     FLIP: 'flip',
     SUM_DIGITS: 'Σ',
     SIGN: 'sgn',
-    FACTORIAL: 'n!'
+    FACTORIAL: 'n!',
+    POW_2: '2^n'
 };
 
 // Operazioni speciali: non si compongono con altre operazioni
-const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP, OperationType.SUM_DIGITS, OperationType.SIGN, OperationType.FACTORIAL];
+const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP, OperationType.SUM_DIGITS, OperationType.SIGN, OperationType.FACTORIAL, OperationType.POW_2];
 
 // Categorie di difficoltà
 const DifficultyCategory = {
@@ -39,7 +40,8 @@ const DifficultyCategory = {
     SUM_DIGITS: { name: 'Somma Cifre', range: [35, 36] },
     SIGN: { name: 'Segno', range: [37, 38] },
     DIVIDE: { name: 'Divisioni', range: [39, 41] },
-    FACTORIAL: { name: 'Fattoriale', range: [42, 43] }
+    FACTORIAL: { name: 'Fattoriale', range: [42, 43] },
+    POW_2: { name: 'Potenza di 2', range: [44, 45] }
 };
 
 // Funzione helper per ottenere la categoria di difficoltà di un livello
@@ -609,6 +611,27 @@ const levels = [
             { type: SquareType.NUMBER, value: 4 },
             { type: SquareType.NUMBER, value: 24 },
             { type: SquareType.OPERATION, value: OperationType.FACTORIAL }
+        ]
+    },
+    // === POTENZA DI 2 (45-46) ===
+    {
+        name: "Potenza Due",
+        // Soluzione: 3×2^n=8, 8+8 spariscono
+        solution: "3×2^n=8, 8+8 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 3 },
+            { type: SquareType.NUMBER, value: 8 },
+            { type: SquareType.OPERATION, value: OperationType.POW_2 }
+        ]
+    },
+    {
+        name: "Potenza Dieci",
+        // Soluzione: 10×2^n=1024, 1024+1024 spariscono
+        solution: "10×2^n=1024, 1024+1024 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 10 },
+            { type: SquareType.NUMBER, value: 1024 },
+            { type: SquareType.OPERATION, value: OperationType.POW_2 }
         ]
     }
 ];

--- a/script.js
+++ b/script.js
@@ -43,6 +43,8 @@ class SquareContent {
                 return 'Estrai segno';
             case OperationType.FACTORIAL:
                 return 'Fattoriale (solo 1-6)';
+            case OperationType.POW_2:
+                return 'Potenza di 2 (solo 1-10)';
         }
     }
 
@@ -83,6 +85,9 @@ function applyOperation(num, operationContent) {
             const factorials = [1, 1, 2, 6, 24, 120, 720];
             return factorials[num];
         }
+        case OperationType.POW_2:
+            // Potenza di 2: 2^n
+            return Math.pow(2, num);
     }
 
     // Se è un contenuto con composedMultiplier o getMultiplier può gestirlo
@@ -160,6 +165,11 @@ function canApplyOperation(num, operationContent) {
     // Fattoriale: solo numeri da 1 a 6
     if (opValue === OperationType.FACTORIAL) {
         return Number.isInteger(num) && num >= 1 && num <= 6;
+    }
+
+    // Potenza di 2: solo numeri da 1 a 10
+    if (opValue === OperationType.POW_2) {
+        return Number.isInteger(num) && num >= 1 && num <= 10;
     }
 
     // Tutte le altre operazioni sono sempre applicabili


### PR DESCRIPTION
## Summary
- Aggiunta operazione `2^n` (potenza di 2)
- Applicabile solo a numeri da 1 a 10
- Crea potenze di 2: 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024

## Test plan
- [ ] Verificare che `2^n` applicato a 3 produca 8
- [ ] Verificare che `2^n` applicato a 11 mostri feedback rejected
- [ ] Completare i livelli 45 e 46

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)