### PR TITLE
feat: aggiungi operazioni modulo %2, %3, %5, %10 (#20)

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -20,11 +20,15 @@ const OperationType = {
     SIGN: 'sgn',
     FACTORIAL: 'n!',
     POW_2: '2^n',
-    POW_3: '3^n'
+    POW_3: '3^n',
+    MOD_2: '%2',
+    MOD_3: '%3',
+    MOD_5: '%5',
+    MOD_10: '%10'
 };
 
 // Operazioni speciali: non si compongono con altre operazioni
-const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP, OperationType.SUM_DIGITS, OperationType.SIGN, OperationType.FACTORIAL, OperationType.POW_2, OperationType.POW_3];
+const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP, OperationType.SUM_DIGITS, OperationType.SIGN, OperationType.FACTORIAL, OperationType.POW_2, OperationType.POW_3, OperationType.MOD_2, OperationType.MOD_3, OperationType.MOD_5, OperationType.MOD_10];
 
 // Categorie di difficoltà
 const DifficultyCategory = {
@@ -43,7 +47,8 @@ const DifficultyCategory = {
     DIVIDE: { name: 'Divisioni', range: [39, 41] },
     FACTORIAL: { name: 'Fattoriale', range: [42, 43] },
     POW_2: { name: 'Potenza di 2', range: [44, 45] },
-    POW_3: { name: 'Potenza di 3', range: [46, 47] }
+    POW_3: { name: 'Potenza di 3', range: [46, 47] },
+    MODULO: { name: 'Modulo', range: [48, 51] }
 };
 
 // Funzione helper per ottenere la categoria di difficoltà di un livello
@@ -655,6 +660,47 @@ const levels = [
             { type: SquareType.NUMBER, value: 3 },
             { type: SquareType.NUMBER, value: 27 },
             { type: SquareType.OPERATION, value: OperationType.POW_3 }
+        ]
+    },
+    // === MODULO (49-52) ===
+    {
+        name: "Modulo Due",
+        // Soluzione: 7×%2=1, 1+1 spariscono
+        solution: "7×%2=1, 1+1 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 7 },
+            { type: SquareType.NUMBER, value: 1 },
+            { type: SquareType.OPERATION, value: OperationType.MOD_2 }
+        ]
+    },
+    {
+        name: "Modulo Tre",
+        // Soluzione: 17×%3=2, 2+2 spariscono
+        solution: "17×%3=2, 2+2 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 17 },
+            { type: SquareType.NUMBER, value: 2 },
+            { type: SquareType.OPERATION, value: OperationType.MOD_3 }
+        ]
+    },
+    {
+        name: "Modulo Cinque",
+        // Soluzione: 23×%5=3, 3+3 spariscono
+        solution: "23×%5=3, 3+3 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 23 },
+            { type: SquareType.NUMBER, value: 3 },
+            { type: SquareType.OPERATION, value: OperationType.MOD_5 }
+        ]
+    },
+    {
+        name: "Ultima Cifra",
+        // Soluzione: 234×%10=4, 4+4 spariscono (mod10 = ultima cifra)
+        solution: "234×%10=4, 4+4 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 234 },
+            { type: SquareType.NUMBER, value: 4 },
+            { type: SquareType.OPERATION, value: OperationType.MOD_10 }
         ]
     }
 ];

--- a/script.js
+++ b/script.js
@@ -47,6 +47,14 @@ class SquareContent {
                 return 'Potenza di 2 (solo 1-10)';
             case OperationType.POW_3:
                 return 'Potenza di 3 (solo 1-6)';
+            case OperationType.MOD_2:
+                return 'Modulo 2 (resto)';
+            case OperationType.MOD_3:
+                return 'Modulo 3 (resto)';
+            case OperationType.MOD_5:
+                return 'Modulo 5 (resto)';
+            case OperationType.MOD_10:
+                return 'Modulo 10 (ultima cifra)';
         }
     }
 
@@ -93,6 +101,18 @@ function applyOperation(num, operationContent) {
         case OperationType.POW_3:
             // Potenza di 3: 3^n
             return Math.pow(3, num);
+        case OperationType.MOD_2:
+            // Modulo 2 (sempre positivo)
+            return ((num % 2) + 2) % 2;
+        case OperationType.MOD_3:
+            // Modulo 3 (sempre positivo)
+            return ((num % 3) + 3) % 3;
+        case OperationType.MOD_5:
+            // Modulo 5 (sempre positivo)
+            return ((num % 5) + 5) % 5;
+        case OperationType.MOD_10:
+            // Modulo 10 (sempre positivo - ultima cifra)
+            return ((num % 10) + 10) % 10;
     }
 
     // Se è un contenuto con composedMultiplier o getMultiplier può gestirlo


### PR DESCRIPTION
## Summary
- Aggiunte operazioni modulo: MOD_2 (%2), MOD_3 (%3), MOD_5 (%5), MOD_10 (%10)
- Restituiscono il resto della divisione per N
- Per numeri negativi: usa il modulo matematico (sempre positivo)
  - Es: `-7 mod 3` → `2` (non -1)
- Aggiunte a SpecialOperations (non componibili)
- Aggiunti 4 livelli di test (Modulo Due, Modulo Tre, Modulo Cinque, Ultima Cifra)
- Aggiunta categoria MODULO in DifficultyCategory

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)