### PR TITLE
feat: aggiungi operazione radice quadrata √ (#19)

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -24,11 +24,12 @@ const OperationType = {
     MOD_2: '%2',
     MOD_3: '%3',
     MOD_5: '%5',
-    MOD_10: '%10'
+    MOD_10: '%10',
+    SQRT: '√'
 };
 
 // Operazioni speciali: non si compongono con altre operazioni
-const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP, OperationType.SUM_DIGITS, OperationType.SIGN, OperationType.FACTORIAL, OperationType.POW_2, OperationType.POW_3, OperationType.MOD_2, OperationType.MOD_3, OperationType.MOD_5, OperationType.MOD_10];
+const SpecialOperations = [OperationType.ABS, OperationType.SQUARE, OperationType.FLIP, OperationType.SUM_DIGITS, OperationType.SIGN, OperationType.FACTORIAL, OperationType.POW_2, OperationType.POW_3, OperationType.MOD_2, OperationType.MOD_3, OperationType.MOD_5, OperationType.MOD_10, OperationType.SQRT];
 
 // Categorie di difficoltà
 const DifficultyCategory = {
@@ -48,7 +49,8 @@ const DifficultyCategory = {
     FACTORIAL: { name: 'Fattoriale', range: [42, 43] },
     POW_2: { name: 'Potenza di 2', range: [44, 45] },
     POW_3: { name: 'Potenza di 3', range: [46, 47] },
-    MODULO: { name: 'Modulo', range: [48, 51] }
+    MODULO: { name: 'Modulo', range: [48, 51] },
+    SQRT: { name: 'Radice Quadrata', range: [52, 54] }
 };
 
 // Funzione helper per ottenere la categoria di difficoltà di un livello
@@ -701,6 +703,38 @@ const levels = [
             { type: SquareType.NUMBER, value: 234 },
             { type: SquareType.NUMBER, value: 4 },
             { type: SquareType.OPERATION, value: OperationType.MOD_10 }
+        ]
+    },
+    // === RADICE QUADRATA (53-55) ===
+    {
+        name: "Radice",
+        // Soluzione: 16×√=4, 4+4 spariscono
+        solution: "16×√=4, 4+4 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 16 },
+            { type: SquareType.NUMBER, value: 4 },
+            { type: SquareType.OPERATION, value: OperationType.SQRT }
+        ]
+    },
+    {
+        name: "Radice Cento",
+        // Soluzione: 100×√=10, 10+10 spariscono
+        solution: "100×√=10, 10+10 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 100 },
+            { type: SquareType.NUMBER, value: 10 },
+            { type: SquareType.OPERATION, value: OperationType.SQRT }
+        ]
+    },
+    {
+        name: "Inversi",
+        // Soluzione: √+x²=identità (spariscono), 5+5 spariscono
+        solution: "√+x²=identità (spariscono), 5+5 spariscono",
+        squares: [
+            { type: SquareType.NUMBER, value: 5 },
+            { type: SquareType.NUMBER, value: 5 },
+            { type: SquareType.OPERATION, value: OperationType.SQRT },
+            { type: SquareType.OPERATION, value: OperationType.SQUARE }
         ]
     }
 ];

--- a/script.js
+++ b/script.js
@@ -55,6 +55,8 @@ class SquareContent {
                 return 'Modulo 5 (resto)';
             case OperationType.MOD_10:
                 return 'Modulo 10 (ultima cifra)';
+            case OperationType.SQRT:
+                return 'Radice quadrata (solo quadrati perfetti)';
         }
     }
 
@@ -113,6 +115,9 @@ function applyOperation(num, operationContent) {
         case OperationType.MOD_10:
             // Modulo 10 (sempre positivo - ultima cifra)
             return ((num % 10) + 10) % 10;
+        case OperationType.SQRT:
+            // Radice quadrata
+            return Math.sqrt(num);
     }
 
     // Se è un contenuto con composedMultiplier o getMultiplier può gestirlo
@@ -200,6 +205,13 @@ function canApplyOperation(num, operationContent) {
     // Potenza di 3: solo numeri da 1 a 6
     if (opValue === OperationType.POW_3) {
         return Number.isInteger(num) && num >= 1 && num <= 6;
+    }
+
+    // Radice quadrata: solo quadrati perfetti positivi
+    if (opValue === OperationType.SQRT) {
+        if (num < 0) return false;
+        const sqrt = Math.sqrt(num);
+        return Number.isInteger(sqrt);
     }
 
     // Tutte le altre operazioni sono sempre applicabili
@@ -549,6 +561,16 @@ function combineSquares(dragged, target) {
         // Operazione + Operazione = Compone (solo se entrambe non-speciali)
         const isSpecial1 = content1.isSpecialOperation();
         const isSpecial2 = content2.isSpecialOperation();
+
+        // Caso speciale: √ + x² = identità (si annullano)
+        const isSqrtSquareCombo = (content1.value === OperationType.SQRT && content2.value === OperationType.SQUARE) ||
+                                   (content1.value === OperationType.SQUARE && content2.value === OperationType.SQRT);
+        if (isSqrtSquareCombo) {
+            removeSquare(dragged);
+            removeSquare(target);
+            checkWin();
+            return;
+        }
 
         // Le operazioni speciali non si compongono tra loro né con altre operazioni
         if (isSpecial1 || isSpecial2) {


### PR DESCRIPTION
## Summary
- Aggiunta operazione SQRT (√) che calcola la radice quadrata
- Si applica SOLO a quadrati perfetti positivi (1, 4, 9, 16, 25, ...)
- Numeri non quadrati perfetti o negativi: operazione non applicabile
- Caso speciale: √ + x² = identità (si annullano - entrambi spariscono)
- Aggiunti 3 livelli di test (Radice, Radice Cento, Inversi)
- Aggiunta categoria SQRT in DifficultyCategory

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)