### PR TITLE
feat: aggiungi effetto bordo luminoso sui quadrati creati (#35)

### DIFF
--- a/script.js
+++ b/script.js
@@ -565,7 +565,8 @@ function combineSquares(dragged, target) {
             if (targetContent.composedMultiplier) {
                 newContent.composedMultiplier = targetContent.composedMultiplier;
             }
-            createSquare(newContent, 0);
+            const newSquare = createSquare(newContent, 0);
+            applyGlow(newSquare);
             updateUI();
             checkWin();
         }, 300);
@@ -601,7 +602,9 @@ function combineSquares(dragged, target) {
         setTimeout(() => {
             divisors.forEach((div, index) => {
                 const newContent = new SquareContent(SquareType.NUMBER, div);
-                createSquare(newContent, index * 100);
+                const newSquare = createSquare(newContent, index * 100);
+                // Applica glow con delay per sincronizzare con l'animazione
+                setTimeout(() => applyGlow(newSquare), index * 100);
             });
             updateUI();
             checkWin();
@@ -692,6 +695,7 @@ function combineSquares(dragged, target) {
     setTimeout(() => {
         const newSquare = createSquareFromResult(result, targetNextSibling);
         newSquare.classList.add('merging');
+        applyGlow(newSquare);
         updateUI();
         checkWin();
     }, 300);
@@ -761,6 +765,18 @@ function removeSquare(square) {
         gameState.squares = gameState.squares.filter(s => s.id != id);
         updateUI();
     }, 300);
+}
+
+// Applica effetto glow temporaneo a un quadrato
+function applyGlow(square) {
+    square.classList.add('glow');
+    setTimeout(() => {
+        square.classList.remove('glow');
+        square.classList.add('glow-fade');
+        setTimeout(() => {
+            square.classList.remove('glow-fade');
+        }, 500);
+    }, 2000);
 }
 
 // Cestina un quadrato

--- a/style.css
+++ b/style.css
@@ -206,6 +206,17 @@ h1 {
     animation: merge 0.5s ease-out;
 }
 
+/* Effetto glow per quadrati creati da operazioni */
+.square.glow {
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.8), 0 0 40px rgba(255, 255, 255, 0.4);
+    transition: box-shadow 0.3s ease;
+}
+
+.square.glow-fade {
+    box-shadow: none;
+    transition: box-shadow 0.5s ease;
+}
+
 @keyframes reject {
     0%, 100% { transform: translateX(0); }
     20% { transform: translateX(-5px); }


### PR DESCRIPTION
## Summary
- Aggiunta classe CSS `glow` con `box-shadow` bianco luminoso
- Applicazione automatica dell'effetto ai quadrati creati dopo operazioni
- L'effetto dura 2 secondi e scompare con transizione smooth

## Implementazione
- **style.css**: nuove classi `.glow` e `.glow-fade` per l'effetto visivo
- **script.js**: funzione `applyGlow()` applicata in tutti i punti dove vengono creati quadrati da operazioni:
  - Combinazione numero+operazione o operazione+operazione
  - Operazione CLONE (duplicazione)
  - Operazione DIVISORS (esplosione in divisori)

## Test plan
- [ ] Combina un numero con un'operazione (es. x2) → il risultato ha bordo luminoso
- [ ] Combina due operazioni → il risultato ha bordo luminoso
- [ ] Usa l'operazione CLONE → la copia ha bordo luminoso
- [ ] Usa l'operazione DIVISORS → tutti i divisori hanno bordo luminoso
- [ ] Verifica che l'effetto sparisca dopo 2 secondi con transizione smooth

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)