### PR TITLE
Fix: correggi bug visualizzazione drag (#36)

### DIFF
--- a/script.js
+++ b/script.js
@@ -413,9 +413,29 @@ function setupSquareDragEvents(square) {
 // Gestori drag and drop
 function handleDragStart(e) {
     gameState.draggedSquare = this;
-    this.classList.add('dragging');
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', this.dataset.id);
+
+    // Crea un clone isolato per l'immagine drag
+    const dragImage = this.cloneNode(true);
+    dragImage.style.position = 'absolute';
+    dragImage.style.top = '-1000px';
+    dragImage.style.left = '-1000px';
+    dragImage.style.opacity = '0.9';
+    dragImage.style.transform = 'scale(1.1)';
+    dragImage.style.boxShadow = '0 15px 40px rgba(0, 0, 0, 0.4)';
+    document.body.appendChild(dragImage);
+
+    // Usa il clone come immagine drag (centrato)
+    e.dataTransfer.setDragImage(dragImage, 40, 40);
+
+    // Rimuovi il clone dopo che il browser l'ha catturato
+    requestAnimationFrame(() => {
+        dragImage.remove();
+    });
+
+    // Nascondi l'elemento originale
+    this.classList.add('dragging');
 }
 
 function handleDragEnd(e) {

--- a/style.css
+++ b/style.css
@@ -103,10 +103,8 @@ h1 {
 }
 
 .square.dragging {
-    opacity: 0.8;
-    transform: scale(1.1);
-    z-index: 1000;
-    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    pointer-events: none;
 }
 
 .square.drag-over {


### PR DESCRIPTION
## Summary
- Risolve la duplicazione del quadrato trascinato usando `setDragImage` con un clone isolato
- Corregge il trascinamento errato di elementi adiacenti
- Nasconde l'elemento originale durante il drag

## Modifiche
- **script.js**: Aggiunto clone isolato per l'immagine drag con `setDragImage`
- **style.css**: Modificato `.square.dragging` per nascondere completamente l'elemento

## Test plan
- [ ] Verificare che solo il quadrato selezionato si muova durante il drag
- [ ] Verificare che non ci siano duplicazioni visive
- [ ] Verificare che gli altri quadrati non vengano trascinati

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)