### PR TITLE
fix: correggi drag and drop (#39)

### DIFF
--- a/script.js
+++ b/script.js
@@ -416,26 +416,11 @@ function handleDragStart(e) {
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', this.dataset.id);
 
-    // Crea un clone isolato per l'immagine drag
-    const dragImage = this.cloneNode(true);
-    dragImage.style.position = 'absolute';
-    dragImage.style.top = '-1000px';
-    dragImage.style.left = '-1000px';
-    dragImage.style.opacity = '0.9';
-    dragImage.style.transform = 'scale(1.1)';
-    dragImage.style.boxShadow = '0 15px 40px rgba(0, 0, 0, 0.4)';
-    document.body.appendChild(dragImage);
-
-    // Usa il clone come immagine drag (centrato)
-    e.dataTransfer.setDragImage(dragImage, 40, 40);
-
-    // Rimuovi il clone dopo che il browser l'ha catturato
+    // Nasconde l'elemento originale dopo che il browser ha catturato l'immagine drag
+    const element = this;
     requestAnimationFrame(() => {
-        dragImage.remove();
+        element.classList.add('dragging');
     });
-
-    // Nascondi l'elemento originale
-    this.classList.add('dragging');
 }
 
 function handleDragEnd(e) {

--- a/style.css
+++ b/style.css
@@ -103,8 +103,7 @@ h1 {
 }
 
 .square.dragging {
-    opacity: 0;
-    pointer-events: none;
+    opacity: 0 !important;
 }
 
 .square.drag-over {


### PR DESCRIPTION
## Summary
- Corretto bug che impediva il drag and drop dei quadrati
- L'elemento originale viene nascosto con `requestAnimationFrame` dopo che il browser ha catturato l'immagine drag
- Rimossa logica del clone non necessaria che causava problemi di timing

## Test plan
- [ ] Verificare che i quadrati possano essere trascinati
- [ ] Verificare che durante il drag l'elemento originale scompaia
- [ ] Verificare che il rilascio su un altro quadrato attivi la combinazione
- [ ] Verificare che il rilascio in zona vuota funzioni correttamente

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)