### PR TITLE
feat: visualizza potenze con esponente in apice

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -19,8 +19,8 @@ const OperationType = {
     SUM_DIGITS: 'Σ',
     SIGN: 'sgn',
     FACTORIAL: 'n!',
-    POW_2: '2^n',
-    POW_3: '3^n',
+    POW_2: '2ⁿ',
+    POW_3: '3ⁿ',
     MOD_2: '%2',
     MOD_3: '%3',
     MOD_5: '%5',
@@ -629,8 +629,8 @@ const levels = [
     // === POTENZA DI 2 (45-46) ===
     {
         name: "Potenza Due",
-        // Soluzione: 3×2^n=8, 8+8 spariscono
-        solution: "3×2^n=8, 8+8 spariscono",
+        // Soluzione: 3×2ⁿ=8, 8+8 spariscono
+        solution: "3×2ⁿ=8, 8+8 spariscono",
         squares: [
             { type: SquareType.NUMBER, value: 3 },
             { type: SquareType.NUMBER, value: 8 },
@@ -639,8 +639,8 @@ const levels = [
     },
     {
         name: "Potenza Dieci",
-        // Soluzione: 10×2^n=1024, 1024+1024 spariscono
-        solution: "10×2^n=1024, 1024+1024 spariscono",
+        // Soluzione: 10×2ⁿ=1024, 1024+1024 spariscono
+        solution: "10×2ⁿ=1024, 1024+1024 spariscono",
         squares: [
             { type: SquareType.NUMBER, value: 10 },
             { type: SquareType.NUMBER, value: 1024 },
@@ -650,8 +650,8 @@ const levels = [
     // === POTENZA DI 3 (47-48) ===
     {
         name: "Potenza Tre",
-        // Soluzione: 2×3^n=9, 9+9 spariscono
-        solution: "2×3^n=9, 9+9 spariscono",
+        // Soluzione: 2×3ⁿ=9, 9+9 spariscono
+        solution: "2×3ⁿ=9, 9+9 spariscono",
         squares: [
             { type: SquareType.NUMBER, value: 2 },
             { type: SquareType.NUMBER, value: 9 },
@@ -660,8 +660,8 @@ const levels = [
     },
     {
         name: "Potenza Ventisette",
-        // Soluzione: 3×3^n=27, 27+27 spariscono
-        solution: "3×3^n=27, 27+27 spariscono",
+        // Soluzione: 3×3ⁿ=27, 27+27 spariscono
+        solution: "3×3ⁿ=27, 27+27 spariscono",
         squares: [
             { type: SquareType.NUMBER, value: 3 },
             { type: SquareType.NUMBER, value: 27 },

--- a/script.js
+++ b/script.js
@@ -102,10 +102,10 @@ function applyOperation(num, operationContent) {
             return factorials[num];
         }
         case OperationType.POW_2:
-            // Potenza di 2: 2^n
+            // Potenza di 2: 2ⁿ
             return Math.pow(2, num);
         case OperationType.POW_3:
-            // Potenza di 3: 3^n
+            // Potenza di 3: 3ⁿ
             return Math.pow(3, num);
         case OperationType.MOD_2:
             // Modulo 2 (sempre positivo)


### PR DESCRIPTION
## Summary
- Sostituito `2^n` con `2ⁿ` e `3^n` con `3ⁿ` usando caratteri Unicode superscript
- Aggiornati i commenti e le soluzioni dei livelli per consistenza

## Test plan
- [ ] Aprire il gioco nel browser
- [ ] Navigare al livello 45 "Potenza Due" o 47 "Potenza Tre"
- [ ] Verificare che i quadrati operazione mostrino `2ⁿ` e `3ⁿ` con esponente in apice

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)