### PR TITLE
feat: operazione divisori solo per numeri composti

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -764,12 +764,13 @@ const levels = [
     },
     // === DIVISORI (58-59) ===
     {
-        name: "Esplosione Primo",
-        // Soluzione: 7×÷→=7 (numero primo crea solo se stesso), 7+7 spariscono
-        solution: "7×÷→=7, 7+7 spariscono",
+        name: "Esplosione Quattro",
+        // Soluzione: 4×÷→=[2,2], 2+2 spariscono, 2+2 spariscono
+        solution: "4×÷→=[2,2], 2+2 spariscono, 2+2 spariscono",
         squares: [
-            { type: SquareType.NUMBER, value: 7 },
-            { type: SquareType.NUMBER, value: 7 },
+            { type: SquareType.NUMBER, value: 4 },
+            { type: SquareType.NUMBER, value: 2 },
+            { type: SquareType.NUMBER, value: 2 },
             { type: SquareType.OPERATION, value: OperationType.DIVISORS }
         ]
     },

--- a/script.js
+++ b/script.js
@@ -218,12 +218,25 @@ function canApplyOperation(num, operationContent) {
         return Number.isInteger(sqrt);
     }
 
-    // Divisori: solo numeri interi > 1, limite a 100 per evitare troppi divisori
+    // Divisori: solo numeri composti (no primi), interi > 1, limite a 100
     if (opValue === OperationType.DIVISORS) {
-        return Number.isInteger(num) && num > 1 && num <= 100;
+        if (!Number.isInteger(num) || num <= 1 || num > 100) return false;
+        // Escludi numeri primi: i fattori primi sarebbero solo il numero stesso
+        return !isPrime(num);
     }
 
     // Tutte le altre operazioni sono sempre applicabili
+    return true;
+}
+
+// Funzione per verificare se un numero è primo
+function isPrime(num) {
+    if (num < 2) return false;
+    if (num === 2) return true;
+    if (num % 2 === 0) return false;
+    for (let i = 3; i * i <= num; i += 2) {
+        if (num % i === 0) return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
## Summary

- L'operazione divisori ora funziona solo su numeri composti (esclusi i numeri primi)
- I numeri primi restituirebbero solo se stessi come fattore, violando il requisito di non conservare il numero originale
- Aggiornato il livello "Esplosione Primo" → "Esplosione Quattro" per usare un numero composto

## Modifiche

- `script.js`: Aggiunta funzione `isPrime()` e modificato `canApplyOperation()` per DIVISORS
- `levels.js`: Aggiornato livello con numero 4 invece di 7

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)