### PR TITLE
Solver: limita a max 5 soluzioni per coppia finale

### DIFF
--- a/solver.html
+++ b/solver.html
@@ -372,15 +372,35 @@
             }
 
             if (r.solutions.length > 0) {
-                const showCount = Math.min(r.solutions.length, 5);
-                html += `
-                    <div class="solutions-section">
-                        <h4>Soluzioni${r.solutions.length > 5 ? ` (prime ${showCount} di ${r.solutions.length})` : ''}</h4>
-                        ${r.solutions.slice(0, showCount).map((sol, i) => `
-                            <div class="solution-item">${i + 1}. ${sol.join(' → ')}</div>
-                        `).join('')}
-                    </div>
-                `;
+                const MAX_PER_GROUP = 5;
+                // Raggruppa per coppia finale
+                const groups = {};
+                for (const sol of r.solutions) {
+                    if (sol.length === 0) continue;
+                    const finalMove = sol[sol.length - 1];
+                    if (!groups[finalMove]) groups[finalMove] = [];
+                    groups[finalMove].push(sol);
+                }
+
+                html += `<div class="solutions-section">`;
+                html += `<h4>Soluzioni per coppia finale (max ${MAX_PER_GROUP} per gruppo)</h4>`;
+
+                for (const [finalMove, groupSolutions] of Object.entries(groups)) {
+                    const shown = groupSolutions.slice(0, MAX_PER_GROUP);
+                    const remaining = groupSolutions.length - shown.length;
+
+                    html += `<div style="margin: 15px 0;">`;
+                    html += `<strong style="color: #4facfe;">[${finalMove}]</strong> <span style="color: rgba(255,255,255,0.6);">(${groupSolutions.length} soluzioni)</span>`;
+                    html += shown.map((sol, i) => `
+                        <div class="solution-item">${i + 1}. ${sol.join(' → ')}</div>
+                    `).join('');
+                    if (remaining > 0) {
+                        html += `<div style="color: rgba(255,255,255,0.5); font-style: italic; padding: 5px 15px;">... e altre ${remaining} soluzioni</div>`;
+                    }
+                    html += `</div>`;
+                }
+
+                html += `</div>`;
             }
 
             html += '</div>';

--- a/solver.js
+++ b/solver.js
@@ -550,8 +550,25 @@ function analyzeAllLevels() {
     return results;
 }
 
+// Raggruppa soluzioni per coppia finale (ultima mossa)
+function groupSolutionsByFinalPair(solutions) {
+    const groups = {};
+
+    for (const sol of solutions) {
+        if (sol.length === 0) continue;
+        const finalMove = sol[sol.length - 1];
+        if (!groups[finalMove]) {
+            groups[finalMove] = [];
+        }
+        groups[finalMove].push(sol);
+    }
+
+    return groups;
+}
+
 // Formatta i risultati per la visualizzazione
 function formatResults(results) {
+    const MAX_SOLUTIONS_PER_GROUP = 5;
     let output = '';
 
     for (const r of results) {
@@ -570,14 +587,25 @@ function formatResults(results) {
                 output += `Prime mosse PERICOLOSE: ${r.unsafeFirstMoves.join(', ')}\n`;
             }
 
-            if (r.totalSolutions <= 5) {
-                output += `\nSoluzioni:\n`;
-                r.solutions.forEach((sol, i) => {
-                    output += `  ${i + 1}. ${sol.join(' -> ')}\n`;
+            // Raggruppa per coppia finale
+            const groups = groupSolutionsByFinalPair(r.solutions);
+            const groupKeys = Object.keys(groups);
+
+            output += `\nSoluzioni per coppia finale (max ${MAX_SOLUTIONS_PER_GROUP} per gruppo):\n`;
+
+            for (const finalMove of groupKeys) {
+                const groupSolutions = groups[finalMove];
+                const shown = groupSolutions.slice(0, MAX_SOLUTIONS_PER_GROUP);
+                const remaining = groupSolutions.length - shown.length;
+
+                output += `\n  [${finalMove}] (${groupSolutions.length} soluzioni):\n`;
+                shown.forEach((sol, i) => {
+                    output += `    ${i + 1}. ${sol.join(' -> ')}\n`;
                 });
-            } else {
-                output += `\nPrima soluzione:\n`;
-                output += `  ${r.solutions[0].join(' -> ')}\n`;
+
+                if (remaining > 0) {
+                    output += `    ... e altre ${remaining} soluzioni\n`;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Raggruppa le soluzioni per l'ultima mossa (coppia di numeri finali eliminata)
- Mostra massimo 5 soluzioni per ogni gruppo
- Indica quante altre soluzioni esistono se superiori a 5 (es. "... e altre 3 soluzioni")

Closes #52

## Test plan

- [ ] Aprire solver.html
- [ ] Analizzare un livello con molte soluzioni
- [ ] Verificare che le soluzioni siano raggruppate per coppia finale
- [ ] Verificare che ogni gruppo mostri max 5 soluzioni con conteggio delle extra

🤖 Generated with [Claude Code](https://claude.com/claude-code)