### PR TITLE
fix: usa clone isolato per drag image (#56)

### DIFF
--- a/script.js
+++ b/script.js
@@ -486,7 +486,23 @@ function handleDragStart(e) {
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', this.dataset.id);
 
-    // Nasconde l'elemento originale dopo che il browser ha catturato l'immagine drag
+    // Crea un clone isolato per l'immagine di drag
+    // Questo evita che vengano catturati elementi adiacenti
+    const clone = this.cloneNode(true);
+    clone.style.position = 'absolute';
+    clone.style.top = '-9999px';
+    clone.style.left = '-9999px';
+    clone.style.width = this.offsetWidth + 'px';
+    clone.style.height = this.offsetHeight + 'px';
+    document.body.appendChild(clone);
+
+    // Usa il clone come immagine di drag
+    e.dataTransfer.setDragImage(clone, this.offsetWidth / 2, this.offsetHeight / 2);
+
+    // Rimuovi il clone dopo che il browser ha catturato l'immagine
+    setTimeout(() => clone.remove(), 0);
+
+    // Nasconde l'elemento originale
     const element = this;
     requestAnimationFrame(() => {
         element.classList.add('dragging');


### PR DESCRIPTION
## Summary
- Risolve il bug durante il trascinamento che mostrava parti dei quadrati adiacenti
- Usa `setDragImage` con un clone isolato posizionato fuori dallo schermo per garantire che solo il quadrato trascinato sia visibile

## Causa del bug
Il browser, quando crea l'immagine di drag predefinita, catturava anche elementi visivamente vicini a causa del layout flexbox con gap.

## Soluzione
1. Crea un clone dell'elemento trascinato
2. Posiziona il clone fuori dallo schermo (`top: -9999px`)
3. Usa `setDragImage(clone, ...)` per usare il clone isolato
4. Rimuove il clone dopo che il browser ha catturato l'immagine

## Test plan
- [ ] Aprire il gioco
- [ ] Trascinare un quadrato che ha altri quadrati adiacenti (a destra o sotto)
- [ ] Verificare che l'immagine del drag mostri solo il quadrato trascinato

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)