### PR TITLE
feat: implementa undo e redo per le mosse

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
         <div id="game-area"></div>
 
         <div class="controls">
+            <button id="btn-undo" disabled title="Annulla (Ctrl+Z)">&#8634; Annulla</button>
+            <button id="btn-redo" disabled title="Ripristina (Ctrl+Y)">Ripristina &#8635;</button>
             <button id="btn-reset">Ricomincia Livello</button>
             <button id="btn-prev" disabled>&#8592; Precedente</button>
             <button id="btn-next">Prossimo &#8594;</button>

--- a/style.css
+++ b/style.css
@@ -274,6 +274,11 @@ button#btn-reset {
     background: linear-gradient(135deg, #eb3349 0%, #f45c43 100%);
 }
 
+button#btn-undo,
+button#btn-redo {
+    background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);
+}
+
 /* Messaggio */
 .message {
     position: fixed;


### PR DESCRIPTION
## Summary
- Aggiunge funzionalità di undo e redo per le mosse di gioco
- Pulsanti UI con icone e tooltip
- Shortcut da tastiera: Ctrl+Z (undo), Ctrl+Y o Ctrl+Shift+Z (redo)
- Lo stato include posizione quadrati e slot cestino usati

## Test plan
- [ ] Fare una mossa e premere Undo - deve tornare allo stato precedente
- [ ] Dopo Undo, premere Redo - deve ripristinare la mossa annullata
- [ ] Verificare che i pulsanti siano disabilitati quando non c'è history/future
- [ ] Testare shortcut Ctrl+Z e Ctrl+Y
- [ ] Verificare che cambiando livello la history venga resettata
- [ ] Testare undo/redo con operazioni speciali (clone, divisors)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)