### PR TITLE
feat: script di build per iOS e Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,14 @@
     "build:ios:device": "npm run cap:sync && npx cap run ios",
     "build:android:device": "npm run cap:sync && npx cap run android",
     "open:ios": "npm run cap:sync && npx cap open ios",
-    "open:android": "npm run cap:sync && npx cap open android"
+    "open:android": "npm run cap:sync && npx cap open android",
+    "build:ios": "./scripts/build-ios.sh",
+    "build:ios:sim": "./scripts/build-ios.sh --simulator",
+    "build:ios:archive": "./scripts/build-ios.sh --archive",
+    "build:android": "./scripts/build-android.sh",
+    "build:android:debug": "./scripts/build-android.sh --debug",
+    "build:android:release": "./scripts/build-android.sh --release",
+    "build:android:bundle": "./scripts/build-android.sh --bundle"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+echo "=== Build Android - Quadrati Numeri ==="
+
+# Vai alla root del progetto
+cd "$(dirname "$0")/.."
+
+# 1. Build web assets
+echo "[1/4] Building web assets..."
+npm run build:web
+
+# 2. Sync Capacitor
+echo "[2/4] Syncing Capacitor..."
+npx cap sync android
+
+# 3. Build con Gradle
+echo "[3/4] Building Android project..."
+cd android
+
+# Build debug APK
+if [ "$1" == "--debug" ]; then
+    echo "Building debug APK..."
+    ./gradlew assembleDebug
+    echo ""
+    echo "[4/4] APK debug creato:"
+    echo "  android/app/build/outputs/apk/debug/app-debug.apk"
+
+# Build release APK
+elif [ "$1" == "--release" ]; then
+    echo "Building release APK..."
+    ./gradlew assembleRelease
+    echo ""
+    echo "[4/4] APK release creato:"
+    echo "  android/app/build/outputs/apk/release/app-release-unsigned.apk"
+
+# Build AAB per Play Store
+elif [ "$1" == "--bundle" ]; then
+    echo "Building App Bundle (AAB)..."
+    ./gradlew bundleRelease
+    echo ""
+    echo "[4/4] AAB creato:"
+    echo "  android/app/build/outputs/bundle/release/app-release.aab"
+
+# Clean build
+elif [ "$1" == "--clean" ]; then
+    echo "Cleaning build..."
+    ./gradlew clean
+    echo "[4/4] Clean completato!"
+
+else
+    echo ""
+    echo "Uso: ./scripts/build-android.sh [opzione]"
+    echo ""
+    echo "Opzioni:"
+    echo "  --debug     Build APK debug"
+    echo "  --release   Build APK release (unsigned)"
+    echo "  --bundle    Build AAB per Play Store"
+    echo "  --clean     Pulisci build precedenti"
+    echo ""
+    echo "Per aprire in Android Studio: npm run open:android"
+fi

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+echo "=== Build iOS - Quadrati Numeri ==="
+
+# Vai alla root del progetto
+cd "$(dirname "$0")/.."
+
+# 1. Build web assets
+echo "[1/4] Building web assets..."
+npm run build:web
+
+# 2. Sync Capacitor
+echo "[2/4] Syncing Capacitor..."
+npx cap sync ios
+
+# 3. Build con xcodebuild
+echo "[3/4] Building iOS project..."
+cd ios/App
+
+# Pulisci build precedenti
+xcodebuild clean -project App.xcodeproj -scheme App -configuration Release -quiet 2>/dev/null || true
+
+# Build per simulatore (debug)
+if [ "$1" == "--simulator" ]; then
+    echo "Building for simulator..."
+    xcodebuild build \
+        -project App.xcodeproj \
+        -scheme App \
+        -configuration Debug \
+        -destination 'platform=iOS Simulator,name=iPhone 16' \
+        | grep -E '^(Build|Compile|Link|error:|warning:|\*\*)' || true
+    echo ""
+    echo "[4/4] Build completato per simulatore!"
+
+# Build per device (release)
+elif [ "$1" == "--device" ]; then
+    echo "Building for device..."
+    xcodebuild build \
+        -project App.xcodeproj \
+        -scheme App \
+        -configuration Release \
+        -destination 'generic/platform=iOS' \
+        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_REQUIRED=NO \
+        | grep -E '^(Build|Compile|Link|error:|warning:|\*\*)' || true
+    echo ""
+    echo "[4/4] Build completato per device!"
+
+# Build archive per distribuzione
+elif [ "$1" == "--archive" ]; then
+    echo "Creating archive..."
+    mkdir -p ../build
+    xcodebuild archive \
+        -project App.xcodeproj \
+        -scheme App \
+        -configuration Release \
+        -archivePath ../build/QuadratiNumeri.xcarchive \
+        | grep -E '^(Build|Archive|error:|warning:|\*\*)' || true
+    echo ""
+    echo "[4/4] Archive creato in ios/build/QuadratiNumeri.xcarchive"
+
+else
+    echo ""
+    echo "Uso: ./scripts/build-ios.sh [opzione]"
+    echo ""
+    echo "Opzioni:"
+    echo "  --simulator   Build per simulatore iOS"
+    echo "  --device      Build per dispositivo fisico (no code signing)"
+    echo "  --archive     Crea archive per distribuzione App Store"
+    echo ""
+    echo "Per aprire in Xcode: npm run open:ios"
+fi


### PR DESCRIPTION
## Summary
- Aggiunge `scripts/build-ios.sh` per build iOS (simulatore, device, archive)
- Aggiunge `scripts/build-android.sh` per build Android (debug, release, bundle)
- Nuovi npm scripts: `build:ios`, `build:ios:sim`, `build:android:debug`, etc.

## Uso
```bash
# iOS
npm run build:ios:sim      # Build per simulatore
./scripts/build-ios.sh --archive  # Archive per App Store

# Android
npm run build:android:debug   # APK debug
npm run build:android:bundle  # AAB per Play Store
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)