### PR TITLE
fix: script --device installa e avvia l'app

### DIFF
--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -42,6 +42,14 @@ elif [ "$1" == "--bundle" ]; then
     echo "[4/4] AAB creato:"
     echo "  android/app/build/outputs/bundle/release/app-release.aab"
 
+# Build e installa su device
+elif [ "$1" == "--device" ]; then
+    echo "Building and installing on device..."
+    cd ..
+    npx cap run android
+    echo ""
+    echo "[4/4] App installata e avviata sul dispositivo!"
+
 # Clean build
 elif [ "$1" == "--clean" ]; then
     echo "Cleaning build..."
@@ -53,6 +61,7 @@ else
     echo "Uso: ./scripts/build-android.sh [opzione]"
     echo ""
     echo "Opzioni:"
+    echo "  --device    Build, installa e avvia su dispositivo/emulatore"
     echo "  --debug     Build APK debug"
     echo "  --release   Build APK release (unsigned)"
     echo "  --bundle    Build AAB per Play Store"

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -33,19 +33,13 @@ if [ "$1" == "--simulator" ]; then
     echo ""
     echo "[4/4] Build completato per simulatore!"
 
-# Build per device (release)
+# Build e installa su device
 elif [ "$1" == "--device" ]; then
-    echo "Building for device..."
-    xcodebuild build \
-        -project App.xcodeproj \
-        -scheme App \
-        -configuration Release \
-        -destination 'generic/platform=iOS' \
-        CODE_SIGN_IDENTITY="" \
-        CODE_SIGNING_REQUIRED=NO \
-        | grep -E '^(Build|Compile|Link|error:|warning:|\*\*)' || true
+    echo "Building and installing on device..."
+    cd ../..
+    npx cap run ios
     echo ""
-    echo "[4/4] Build completato per device!"
+    echo "[4/4] App installata e avviata sul dispositivo!"
 
 # Build archive per distribuzione
 elif [ "$1" == "--archive" ]; then
@@ -66,7 +60,7 @@ else
     echo ""
     echo "Opzioni:"
     echo "  --simulator   Build per simulatore iOS"
-    echo "  --device      Build per dispositivo fisico (no code signing)"
+    echo "  --device      Build, installa e avvia su dispositivo fisico"
     echo "  --archive     Crea archive per distribuzione App Store"
     echo ""
     echo "Per aprire in Xcode: npm run open:ios"


### PR DESCRIPTION
## Summary
- `build-ios.sh --device` ora usa `npx cap run ios` per installare e avviare l'app
- `build-android.sh --device` aggiunto, usa `npx cap run android`
- Aggiornati i messaggi di help

## Uso
```bash
./scripts/build-ios.sh --device      # Installa su iPhone/iPad
./scripts/build-android.sh --device  # Installa su Android
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)