### PR TITLE
feat: target opzionale per script --device

### DIFF
--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -42,11 +42,22 @@ elif [ "$1" == "--bundle" ]; then
     echo "[4/4] AAB creato:"
     echo "  android/app/build/outputs/bundle/release/app-release.aab"
 
+# Lista dispositivi disponibili
+elif [ "$1" == "--list" ]; then
+    echo "Dispositivi disponibili:"
+    cd ..
+    npx cap run android --list
+
 # Build e installa su device
 elif [ "$1" == "--device" ]; then
-    echo "Building and installing on device..."
     cd ..
-    npx cap run android
+    if [ -n "$2" ]; then
+        echo "Building and installing on target: $2"
+        npx cap run android --target "$2"
+    else
+        echo "Building and installing on device..."
+        npx cap run android
+    fi
     echo ""
     echo "[4/4] App installata e avviata sul dispositivo!"
 
@@ -61,11 +72,13 @@ else
     echo "Uso: ./scripts/build-android.sh [opzione]"
     echo ""
     echo "Opzioni:"
-    echo "  --device    Build, installa e avvia su dispositivo/emulatore"
-    echo "  --debug     Build APK debug"
-    echo "  --release   Build APK release (unsigned)"
-    echo "  --bundle    Build AAB per Play Store"
-    echo "  --clean     Pulisci build precedenti"
+    echo "  --list              Elenca dispositivi disponibili"
+    echo "  --device [target]   Build, installa e avvia su dispositivo/emulatore"
+    echo "                      Se target non specificato, mostra menu interattivo"
+    echo "  --debug             Build APK debug"
+    echo "  --release           Build APK release (unsigned)"
+    echo "  --bundle            Build AAB per Play Store"
+    echo "  --clean             Pulisci build precedenti"
     echo ""
     echo "Per aprire in Android Studio: npm run open:android"
 fi

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -33,11 +33,22 @@ if [ "$1" == "--simulator" ]; then
     echo ""
     echo "[4/4] Build completato per simulatore!"
 
+# Lista dispositivi disponibili
+elif [ "$1" == "--list" ]; then
+    echo "Dispositivi disponibili:"
+    cd ../..
+    npx cap run ios --list
+
 # Build e installa su device
 elif [ "$1" == "--device" ]; then
-    echo "Building and installing on device..."
     cd ../..
-    npx cap run ios
+    if [ -n "$2" ]; then
+        echo "Building and installing on target: $2"
+        npx cap run ios --target "$2"
+    else
+        echo "Building and installing on device..."
+        npx cap run ios
+    fi
     echo ""
     echo "[4/4] App installata e avviata sul dispositivo!"
 
@@ -59,9 +70,11 @@ else
     echo "Uso: ./scripts/build-ios.sh [opzione]"
     echo ""
     echo "Opzioni:"
-    echo "  --simulator   Build per simulatore iOS"
-    echo "  --device      Build, installa e avvia su dispositivo fisico"
-    echo "  --archive     Crea archive per distribuzione App Store"
+    echo "  --list             Elenca dispositivi disponibili"
+    echo "  --simulator        Build per simulatore iOS"
+    echo "  --device [target]  Build, installa e avvia su dispositivo"
+    echo "                     Se target non specificato, mostra menu interattivo"
+    echo "  --archive          Crea archive per distribuzione App Store"
     echo ""
     echo "Per aprire in Xcode: npm run open:ios"
 fi


### PR DESCRIPTION
## Summary
- Aggiunge `--list` per elencare dispositivi disponibili
- `--device [target]` ora accetta un target ID opzionale
- Se non specificato, mostra menu interattivo

## Uso
```bash
# Elenca dispositivi
./scripts/build-ios.sh --list

# Installa su dispositivo specifico
./scripts/build-ios.sh --device 00008101-0011511E2190801E
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)