### PR TITLE
fix: corregge posizionamento box livello completato

### DIFF
--- a/style.css
+++ b/style.css
@@ -315,10 +315,8 @@ button#btn-redo {
     z-index: 2000;
     animation: victory-pulse 0.5s ease infinite;
     /* Ensure visibility on mobile */
-    max-width: calc(100vw - 40px);
-    max-height: calc(100vh - 40px);
+    max-width: min(90vw, 400px);
     box-sizing: border-box;
-    margin: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 
 .message h2 {


### PR DESCRIPTION
## Summary
- Rimosso `margin` con `safe-area-inset` che veniva applicato dopo il `transform: translate(-50%, -50%)`, causando lo spostamento del box fuori centro verso destra
- Cambiato `max-width` da `calc(100vw - 40px)` a `min(90vw, 400px)` per dimensionamento più appropriato

## Test plan
- [ ] Completare un livello e verificare che il box sia centrato correttamente
- [ ] Testare su iOS per verificare che funzioni con le safe areas

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)